### PR TITLE
supporting strike-through

### DIFF
--- a/examples/px-reference/text/table-sample.md
+++ b/examples/px-reference/text/table-sample.md
@@ -62,7 +62,25 @@
 
 ## 6. Strikethrough
 
-~~xxx~~
+(1) Simple strikethrough
+
+~~simple strikethrough~~
+
+(2) Strikethrough with Bold text
+
+~~**bold strikethrough**~~
+
+(3) Strikethrough with Italic text
+
+~~*italic strikethrough*~~
+
+(4) Strikethrough with code span
+
+~~`print 'This is a code'`~~
+
+(5) Mixed sample
+
+Hi, this is **a mixed** example. ~~Be **Bold** or *Italtic*, but never `Regular`~~
 
 # Other examples
 

--- a/mime/components/markdown.style.js
+++ b/mime/components/markdown.style.js
@@ -152,5 +152,9 @@ module.exports = {
     codespan: {              // inline code text (monospace)
       font: 'MONOSPACE',
     },
+    del:{
+      height: 1,
+      fillColor: 0x000000ff,
+    }
   },
 };


### PR DESCRIPTION
Done https://github.com/topcoderinc/pxCore/issues/261

Here are the samples.

![image](https://user-images.githubusercontent.com/5657467/50429350-daf65880-08f8-11e9-99e6-c9f83fee4cd0.png)

The samples of strikethrough have been added to https://github.com/billsedison/pxscene/blob/d6cc5822ea92f175f25b1bf41718da41bd279a28/examples/px-reference/text/table-sample.md